### PR TITLE
Fixing door auto-opening on start-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ certs/
 
 # gerber files
 gerber.zip
+
+# Backup files
+*.bak


### PR DESCRIPTION
Fixes an issue with the door automatically opening on every reboot and every disconnect/reconnect of WiFi.  This appears to be due to a spurious MQTT being received (or at least seems to be) immediately after boot or reconnect. Since I can determine the exact cause of this (yet) I simply add a message processing delay where CyGarage will ignore all incoming control messages for the first 5 seconds after the boot sequence completes.  This resolves the issue, but I still haven't resolved where the message is coming from.  The device reports the received control message and I can see a publish sent to CyGarage but I don't see the published message show up in the control topic (when subscribed from the command line) and I don't see any messages being published from OpenHAB2.  I also can't see where the client the message was published *from*.